### PR TITLE
Update regionalpickupShipping.class.php

### DIFF
--- a/lib/regionalpickupShipping.class.php
+++ b/lib/regionalpickupShipping.class.php
@@ -55,9 +55,9 @@ class regionalpickupShipping extends waShipping
 
 		if(
 			!isset($address['country'])
-			|| $address['country'] === $this->rate_zone['country'] 
+			|| $address['country'] !== $this->rate_zone['country'] 
 			|| !isset($address['region'])
-			|| $address['region'] === $this->rate_zone['region']
+			|| $address['region'] !== $this->rate_zone['region']
 		)
 		{
 			return _wp('No suitable pick-up points');


### PR DESCRIPTION
Лучше избегать таких монстроконструкций:

```
while (($namspace_chunk = array_shift($params['namespace'])) !== null) {
```

Тем более когда есть implode и array_walk

```
$namespace = '[' . implode('][', $params['namespace']) . ']';
```

```
$view->assign(
    array(
        'namespace' => $namespace,
        'values' => $values
        'p' => $this
    )
);
```

Работает быстрее в 2 раза, вообще

Массивы "[]" с 5.4 только

По поводу calculate: не будь как WA ) не делай if в if в if в ... лучше сразу return, код будет компактнее и читабильнее, по переменным $rates ... $cost: смысла извлекать их до завершения проверки нет.

по поводу `$view->assign('p', $this)` а зачем? разве стандартный метод перевода в шаблоне модуля доставки работать не будет? и зачем эскейпить всё подряд? если так нужно, то проще включить [$escape_html](http://www.smarty.net/docs/en/variable.escape.html.tpl) в smarty
