### PR TITLE
Локализация: название и описание

### DIFF
--- a/lib/config/plugin.php
+++ b/lib/config/plugin.php
@@ -2,12 +2,12 @@
 /**
  * 
  * @author Serge Rodovnichenko <sergerod@gmail.com>
- * @version 1.1
+ * @version 1.2
  */
 
 return array(
-    'name'        => _wp('Pickup Points'),
-    'description' => _wp('Pickup points by regions (customer selects a pickup point from the list).'),
+    'name'        => 'Pickup Points',
+    'description' => 'Pickup points by regions (customer selects a pickup point from the list).',
     'icon'        => 'img/delivery16.png', //path to module 16x16 icon
     'logo'        => 'img/delivery.png', //path to module logo (recommended logo size: 60x32)
     'version'     => '1.2',


### PR DESCRIPTION
Название и описание плагина (name и description в конфигурационном файле) переводятся с использованием локализации плагина по умолчанию, таким образом указывать 'name' => _wp('НАЗВАНИЕ ПЛАГИНА') не надо — достаточно просто указать 'name'=>'НАЗВАНИЕ ПЛАГИНА'.

http://www.webasyst.ru/developers/docs/plugins/plugin-basics/
